### PR TITLE
Fixed misspelled variable name

### DIFF
--- a/lib/wcf.js
+++ b/lib/wcf.js
@@ -15,7 +15,7 @@ exports.SecurityBindingElement = SecurityBindingElement
 function Proxy(binding, url) {
   this.context = {url: url}
   this.binding = binding
-  this.hanlders = null
+  this.handlers = null
   this.attachments = []
   this.ClientCredentials = {}
   this.ClientCredentials.Username = {}


### PR DESCRIPTION
Changed variable name in the Proxy function to correct spelling.
